### PR TITLE
Fix invalid hook call

### DIFF
--- a/account/webpack.config.js
+++ b/account/webpack.config.js
@@ -1,52 +1,61 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const ESLintPlugin =require("eslint-webpack-plugin");
-const { ModuleFederationPlugin } = require("webpack").container;
+const ESLintPlugin = require("eslint-webpack-plugin");
+const {ModuleFederationPlugin} = require("webpack").container;
 const path = require("path");
 
 module.exports = {
-  entry: "./src/index",
-  mode: "development",
-  devServer: {
-    contentBase: path.join(__dirname, "dist"),
-    port: 3002,
-    historyApiFallback: true,
-  },
-  output: {
-    publicPath: "http://localhost:3002/",
-  },
-  resolve: {
-    extensions: [".ts", ".tsx", ".js"],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: "babel-loader",
-        exclude: /node_modules/,
-        options: {
-          presets: [
-            "@babel/preset-react",
-            "@babel/preset-typescript"
-          ],
-        },
-      },
+    entry: "./src/index",
+    mode: "development",
+    devServer: {
+        contentBase: path.join(__dirname, "dist"),
+        port: 3002,
+        historyApiFallback: true,
+    },
+    output: {
+        publicPath: "http://localhost:3002/",
+    },
+    resolve: {
+        extensions: [".ts", ".tsx", ".js"],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                loader: "babel-loader",
+                exclude: /node_modules/,
+                options: {
+                    presets: [
+                        "@babel/preset-react",
+                        "@babel/preset-typescript"
+                    ],
+                },
+            },
+        ],
+    },
+    plugins: [
+        new ESLintPlugin({
+            extensions: ["js", "jsx", "ts", "tsx"],
+        }),
+        new ModuleFederationPlugin({
+            name: "account",
+            library: {type: "var", name: "account"},
+            filename: "remoteEntry.js",
+            exposes: {
+                "./App": "./src/App",
+            },
+            shared: [
+                {
+                    react: {
+                        singleton: true,
+                    },
+                    "react-dom": {
+                        singleton: true,
+                    },
+                },
+            ],
+        }),
+        new HtmlWebpackPlugin({
+            template: "./public/index.html",
+        }),
     ],
-  },
-  plugins: [
-    new ESLintPlugin({
-      extensions: ["js", "jsx", "ts", "tsx"],
-    }),
-    new ModuleFederationPlugin({
-      name: "account",
-      library: { type: "var", name: "account" },
-      filename: "remoteEntry.js",
-      exposes: {
-        "./App": "./src/App",
-      },
-      shared: ["react", "react-dom"],
-    }),
-    new HtmlWebpackPlugin({
-      template: "./public/index.html",
-    }),
-  ],
 };

--- a/main/src/App.tsx
+++ b/main/src/App.tsx
@@ -13,7 +13,7 @@ import {SWrapper} from './styles';
 const Product = React.lazy(() => import('product/App'));
 const Account = React.lazy(() => import('account/App'));
 
-export default () => {
+const App = () => {
     const store = createStore();
     const [count, setCount] = React.useState(0);
 
@@ -48,3 +48,5 @@ export default () => {
         </Provider>
     )
 }
+
+export default App;

--- a/main/webpack.config.js
+++ b/main/webpack.config.js
@@ -1,52 +1,61 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const ESLintPlugin =require("eslint-webpack-plugin");
-const { ModuleFederationPlugin } = require("webpack").container;
+const ESLintPlugin = require("eslint-webpack-plugin");
+const {ModuleFederationPlugin} = require("webpack").container;
 const path = require("path");
 
 module.exports = {
-  entry: "./src/index",
-  mode: "development",
-  devServer: {
-    contentBase: path.join(__dirname, "dist"),
-    port: 3003,
-    historyApiFallback: true,
-  },
-  output: {
-    publicPath: "http://localhost:3003/",
-  },
-  resolve: {
-    extensions: [".ts", ".tsx", ".js"],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: "babel-loader",
-        exclude: /node_modules/,
-        options: {
-          presets: [
-            "@babel/preset-react",
-            "@babel/preset-typescript"
-          ],
-        },
-      },
+    entry: "./src/index",
+    mode: "development",
+    devServer: {
+        contentBase: path.join(__dirname, "dist"),
+        port: 3003,
+        historyApiFallback: true,
+    },
+    output: {
+        publicPath: "http://localhost:3003/",
+    },
+    resolve: {
+        extensions: [".ts", ".tsx", ".js"],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                loader: "babel-loader",
+                exclude: /node_modules/,
+                options: {
+                    presets: [
+                        "@babel/preset-react",
+                        "@babel/preset-typescript"
+                    ],
+                },
+            },
+        ],
+    },
+    plugins: [
+        new ESLintPlugin({
+            extensions: ["js", "jsx", "ts", "tsx"],
+        }),
+        new ModuleFederationPlugin({
+            name: "main",
+            library: {type: "var", name: "main"},
+            remotes: {
+                product: "product",
+                account: "account",
+            },
+            shared: [
+                {
+                    react: {
+                        singleton: true,
+                    },
+                    "react-dom": {
+                        singleton: true,
+                    },
+                },
+            ],
+        }),
+        new HtmlWebpackPlugin({
+            template: "./public/index.html",
+        }),
     ],
-  },
-  plugins: [
-    new ESLintPlugin({
-      extensions: ["js", "jsx", "ts", "tsx"],
-    }),
-    new ModuleFederationPlugin({
-      name: "main",
-      library: { type: "var", name: "main" },
-      remotes: {
-        product: "product",
-        account: "account",
-      },
-      shared: ["react", "react-dom"],
-    }),
-    new HtmlWebpackPlugin({
-      template: "./public/index.html",
-    }),
-  ],
 };

--- a/product/src/App.tsx
+++ b/product/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {BrowserRouter as Router, Switch, Route, Redirect} from 'react-router-dom';
 import {SLink} from './styles';
 
-export default () => (
+const App = () => (
     <Router>
         <SLink to='/product/'>Default display</SLink>
         <SLink to='/product/cats'>Cats</SLink>
@@ -24,4 +24,6 @@ export default () => (
         </Switch>
     </Router>
 );
+
+export default App;
 

--- a/product/webpack.config.js
+++ b/product/webpack.config.js
@@ -1,52 +1,61 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const ESLintPlugin =require("eslint-webpack-plugin");
-const { ModuleFederationPlugin } = require("webpack").container;
+const ESLintPlugin = require("eslint-webpack-plugin");
+const {ModuleFederationPlugin} = require("webpack").container;
 const path = require("path");
 
 module.exports = {
-  entry: "./src/index",
-  mode: "development",
-  devServer: {
-    contentBase: path.join(__dirname, "dist"),
-    port: 3001,
-    historyApiFallback: true,
-  },
-  output: {
-    publicPath: "http://localhost:3001/",
-  },
-  resolve: {
-    extensions: [".ts", ".tsx", ".js"],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: "babel-loader",
-        exclude: /node_modules/,
-        options: {
-          presets: [
-            "@babel/preset-react",
-            "@babel/preset-typescript"
-          ],
-        },
-      },
+    entry: "./src/index",
+    mode: "development",
+    devServer: {
+        contentBase: path.join(__dirname, "dist"),
+        port: 3001,
+        historyApiFallback: true,
+    },
+    output: {
+        publicPath: "http://localhost:3001/",
+    },
+    resolve: {
+        extensions: [".ts", ".tsx", ".js"],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                loader: "babel-loader",
+                exclude: /node_modules/,
+                options: {
+                    presets: [
+                        "@babel/preset-react",
+                        "@babel/preset-typescript"
+                    ],
+                },
+            },
+        ],
+    },
+    plugins: [
+        new ESLintPlugin({
+            extensions: ["js", "jsx", "ts", "tsx"],
+        }),
+        new ModuleFederationPlugin({
+            name: "product",
+            library: {type: "var", name: "product"},
+            filename: "remoteEntry.js",
+            exposes: {
+                "./App": "./src/App",
+            },
+            shared: [
+                {
+                    react: {
+                        singleton: true,
+                    },
+                    "react-dom": {
+                        singleton: true,
+                    },
+                },
+            ],
+        }),
+        new HtmlWebpackPlugin({
+            template: "./public/index.html",
+        }),
     ],
-  },
-  plugins: [
-    new ESLintPlugin({
-      extensions: ["js", "jsx", "ts", "tsx"],
-    }),
-    new ModuleFederationPlugin({
-      name: "product",
-      library: { type: "var", name: "product" },
-      filename: "remoteEntry.js",
-      exposes: {
-        "./App": "./src/App",
-      },
-      shared: ["react", "react-dom"],
-    }),
-    new HtmlWebpackPlugin({
-      template: "./public/index.html",
-    }),
-  ],
 };


### PR DESCRIPTION
**Invalid hook call** was launch because react was instantiated many time (https://fr.reactjs.org/warnings/invalid-hook-call-warning.html). 

`For making Hooks work, the react import of your application code must resolve to the same module as the react import performed by the react-dom module. `

Module federation webpack plugin offer the ability to instantiate react as a singleton, this way everything work well.